### PR TITLE
supporting backward compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,10 @@
     ],
     "psr-0": {
       "Macellan\\Excel\\": "src/"
-    }
+    },
+    "files": [
+      "src/helpers.php"
+    ]
   },
   "extra": {
         "laravel": {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,16 @@
+<?php
+
+if (!function_exists('starts_with'))
+{
+    /**
+     * Determine if a given string starts with a given substring.
+     *
+     * @param  string  $haystack
+     * @param  string|string[]  $needles
+     * @return bool
+     */
+    function starts_with($haystack, $needles)
+    {
+        return \Illuminate\Support\Str::startsWith($haystack, $needles);
+    }
+}


### PR DESCRIPTION
string helpers were removed in l6. need to revert it back.